### PR TITLE
Feat/#51

### DIFF
--- a/src/main/kotlin/com/example/days/domain/dailycheck/repository/DailyCheckRepository.kt
+++ b/src/main/kotlin/com/example/days/domain/dailycheck/repository/DailyCheckRepository.kt
@@ -1,7 +1,10 @@
 package com.example.days.domain.dailycheck.repository
 
+import com.example.days.domain.dailycheck.dto.response.DailyCheckResponse
 import com.example.days.domain.dailycheck.model.DailyCheck
+import com.example.days.domain.resolution.model.Resolution
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface DailyCheckRepository: JpaRepository<DailyCheck, Long> {
+    fun findByResolutionId(resolutionId: Resolution): List<DailyCheck>
 }

--- a/src/main/kotlin/com/example/days/domain/dailycheck/service/DailyCheckServiceImpl.kt
+++ b/src/main/kotlin/com/example/days/domain/dailycheck/service/DailyCheckServiceImpl.kt
@@ -19,18 +19,23 @@ class DailyCheckServiceImpl(
         val resolution = resolutionRepository.findByIdOrNull(resolutionId) ?: TODO("예외처리")
 
         if(userId == resolution.author.id){
-            dailyCheckRepository.save(DailyCheckRequest.of(request, resolution))
+            return resolutionRepository.findByIdOrNull(resolutionId)
+                ?.let{
+                    it.updateProgress()
+                    dailyCheckRepository.save(DailyCheckRequest.of(request, it))
+                }
+                ?.let { DailyCheckResponse.from(it) }
+                ?: TODO("예외처리")
         }
-        return resolutionRepository.findByIdOrNull(resolutionId)
-            ?.let{ dailyCheckRepository.save(DailyCheckRequest.of(request, it)) }
-            ?.let { DailyCheckResponse.from(it) }
-            ?: TODO("예외처리")
+        else{
+            TODO("같은 사용자가 아닐 때")
+        }
     }
 
     override fun getDailyCheckByList(resolutionId: Long, userId: Long): List<DailyCheckResponse> {
         val resolution = resolutionRepository.findByIdOrNull(resolutionId) ?: TODO("예외처리")
         if(userId == resolution.author.id){
-            return dailyCheckRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"))
+            return dailyCheckRepository.findByResolutionId(resolution)
                 .map { DailyCheckResponse.from(it) }
         }
         else TODO()

--- a/src/main/kotlin/com/example/days/domain/dailycheck/service/DailyCheckServiceImpl.kt
+++ b/src/main/kotlin/com/example/days/domain/dailycheck/service/DailyCheckServiceImpl.kt
@@ -19,13 +19,17 @@ class DailyCheckServiceImpl(
         val resolution = resolutionRepository.findByIdOrNull(resolutionId) ?: TODO("예외처리")
 
         if(userId == resolution.author.id){
-            return resolutionRepository.findByIdOrNull(resolutionId)
-                ?.let{
-                    it.updateProgress()
-                    dailyCheckRepository.save(DailyCheckRequest.of(request, it))
-                }
-                ?.let { DailyCheckResponse.from(it) }
-                ?: TODO("예외처리")
+            if(!resolution.dailyStatus){
+                return resolutionRepository.findByIdOrNull(resolutionId)
+                    ?.let{
+                        it.updateProgress()
+                        dailyCheckRepository.save(DailyCheckRequest.of(request, it))
+                    }
+                    ?.let { DailyCheckResponse.from(it) }
+                    ?: TODO("예외처리")
+            }
+            else
+                TODO("이미 데일리 체크를 끝냈을 때")
         }
         else{
             TODO("같은 사용자가 아닐 때")

--- a/src/main/kotlin/com/example/days/domain/dailycheck/service/DailyCheckServiceImpl.kt
+++ b/src/main/kotlin/com/example/days/domain/dailycheck/service/DailyCheckServiceImpl.kt
@@ -19,17 +19,17 @@ class DailyCheckServiceImpl(
         val resolution = resolutionRepository.findByIdOrNull(resolutionId) ?: TODO("예외처리")
 
         if(userId == resolution.author.id){
-            if(!resolution.dailyStatus){
-                return resolutionRepository.findByIdOrNull(resolutionId)
+            when{
+                resolution.dailyStatus -> TODO("이미 데일리 체크를 끝냈을 때")
+                resolution.completeStatus -> TODO("이미 완료된 목표일때")
+                else -> return resolutionRepository.findByIdOrNull(resolutionId)
                     ?.let{
                         it.updateProgress()
                         dailyCheckRepository.save(DailyCheckRequest.of(request, it))
                     }
                     ?.let { DailyCheckResponse.from(it) }
-                    ?: TODO("예외처리")
+                    ?: TODO("resolution 찾기 오류")
             }
-            else
-                TODO("이미 데일리 체크를 끝냈을 때")
         }
         else{
             TODO("같은 사용자가 아닐 때")

--- a/src/main/kotlin/com/example/days/domain/resolution/controller/ResolutionController.kt
+++ b/src/main/kotlin/com/example/days/domain/resolution/controller/ResolutionController.kt
@@ -18,9 +18,6 @@ import org.springframework.web.bind.annotation.*
 class ResolutionController (
     private val resolutionService: ResolutionService
 ){
-
-    // ^오^: 기본적인 CRUD 만 추가했습니다.
-
     @Operation(summary = "목표 생성")
     @PostMapping
     fun createResolution(

--- a/src/main/kotlin/com/example/days/domain/resolution/dto/response/ResolutionResponse.kt
+++ b/src/main/kotlin/com/example/days/domain/resolution/dto/response/ResolutionResponse.kt
@@ -5,6 +5,7 @@ import com.example.days.domain.resolution.dto.request.ResolutionRequest
 import com.example.days.domain.resolution.model.Resolution
 import com.example.days.domain.user.model.User
 import com.fasterxml.jackson.annotation.JsonFormat
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 data class ResolutionResponse(
@@ -18,6 +19,8 @@ data class ResolutionResponse(
     val likeCount: Long,
 
     // ^오^: 시간 형식으로 값을 바꿔주는 어노테이션
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    val deadline: LocalDate,
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     val createdAt: LocalDateTime,
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
@@ -35,7 +38,8 @@ data class ResolutionResponse(
             progress = resolution.progress,
             likeCount = resolution.likeCount,
             createdAt = resolution.createdAt,
-            updatedAt = resolution.updatedAt
+            updatedAt = resolution.updatedAt,
+            deadline = resolution.deadline
         )
     }
 }

--- a/src/main/kotlin/com/example/days/domain/resolution/dto/response/ResolutionResponse.kt
+++ b/src/main/kotlin/com/example/days/domain/resolution/dto/response/ResolutionResponse.kt
@@ -14,6 +14,7 @@ data class ResolutionResponse(
     val completeStatus: Boolean,
     val dailyStatus: Boolean,
     val category: String,
+    val progress: Long,
     val likeCount: Long,
 
     // ^오^: 시간 형식으로 값을 바꿔주는 어노테이션
@@ -31,6 +32,7 @@ data class ResolutionResponse(
             completeStatus = resolution.completeStatus,
             dailyStatus = resolution.dailyStatus,
             category = resolution.category.name,
+            progress = resolution.progress,
             likeCount = resolution.likeCount,
             createdAt = resolution.createdAt,
             updatedAt = resolution.updatedAt

--- a/src/main/kotlin/com/example/days/domain/resolution/model/Resolution.kt
+++ b/src/main/kotlin/com/example/days/domain/resolution/model/Resolution.kt
@@ -8,6 +8,7 @@ import com.example.days.global.entity.BaseEntity
 import jakarta.persistence.*
 import org.hibernate.annotations.OnDelete
 import org.hibernate.annotations.OnDeleteAction
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Entity
@@ -25,7 +26,7 @@ class Resolution(
     val author: User,
 
     @Column(name = "complete_status")
-    val completeStatus: Boolean = false,
+    var completeStatus: Boolean = false,
 
     @Column(name = "daily_status")
     var dailyStatus: Boolean = false,
@@ -47,7 +48,11 @@ class Resolution(
     val id: Long? = null
 
     @Column(name = "deadline")
-    val deadline: LocalDateTime = createdAt.plusDays(100)
+    val deadline: LocalDate = createdAt.toLocalDate().plusDays(100)
+
+    // 테스트용
+//    @Column(name = "deadline")
+//    val deadline: LocalDateTime = createdAt.plusMinutes(1)
 
     fun updateResolution(updatedTitle: String, updatedDescription: String, updatedCategory: Category){
         title = updatedTitle
@@ -62,6 +67,9 @@ class Resolution(
     fun updateProgress(){
         dailyStatus = true
         progress += 1
+        if(progress == 100L){
+            completeStatus = true
+        }
     }
 }
 

--- a/src/main/kotlin/com/example/days/domain/resolution/model/Resolution.kt
+++ b/src/main/kotlin/com/example/days/domain/resolution/model/Resolution.kt
@@ -31,7 +31,7 @@ class Resolution(
     val dailyStatus: Boolean = false,
 
     @Column(name = "progress")
-    val progress: Long = 0,
+    var progress: Long = 0,
 
     @ManyToOne
     @OnDelete(action = OnDeleteAction.CASCADE)
@@ -57,6 +57,10 @@ class Resolution(
 
     fun updateLikeCount(b: Boolean){
         if(b) likeCount += 1 else likeCount -=1
+    }
+
+    fun updateProgress(){
+        progress += 1
     }
 }
 

--- a/src/main/kotlin/com/example/days/domain/resolution/model/Resolution.kt
+++ b/src/main/kotlin/com/example/days/domain/resolution/model/Resolution.kt
@@ -28,7 +28,7 @@ class Resolution(
     val completeStatus: Boolean = false,
 
     @Column(name = "daily_status")
-    val dailyStatus: Boolean = false,
+    var dailyStatus: Boolean = false,
 
     @Column(name = "progress")
     var progress: Long = 0,
@@ -60,6 +60,7 @@ class Resolution(
     }
 
     fun updateProgress(){
+        dailyStatus = true
         progress += 1
     }
 }

--- a/src/main/kotlin/com/example/days/domain/resolution/repository/QueryResolutionRepository.kt
+++ b/src/main/kotlin/com/example/days/domain/resolution/repository/QueryResolutionRepository.kt
@@ -6,4 +6,6 @@ import org.springframework.data.domain.Page
 
 interface QueryResolutionRepository {
     fun findByPageable(page: Int, sortOrder: SortOrder?): Page<Resolution>
+
+    fun resetResolutionDailyStatus()
 }

--- a/src/main/kotlin/com/example/days/domain/resolution/repository/ResolutionRepository.kt
+++ b/src/main/kotlin/com/example/days/domain/resolution/repository/ResolutionRepository.kt
@@ -4,11 +4,21 @@ import com.example.days.domain.resolution.model.Resolution
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 interface ResolutionRepository: JpaRepository<Resolution, Long>, QueryResolutionRepository{
     @Modifying
     @Transactional
     @Query("UPDATE Resolution r SET r.dailyStatus = false")
     fun resetResolutionDailyStatus2()
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Resolution r SET r.completeStatus = true WHERE r.deadline <= :today")
+    // 테스트 시
+//    fun checkResolutionDeadline(@Param("today") today: LocalDateTime)
+    fun checkResolutionDeadline(@Param("today") today: LocalDate)
 }

--- a/src/main/kotlin/com/example/days/domain/resolution/repository/ResolutionRepository.kt
+++ b/src/main/kotlin/com/example/days/domain/resolution/repository/ResolutionRepository.kt
@@ -2,6 +2,13 @@ package com.example.days.domain.resolution.repository
 
 import com.example.days.domain.resolution.model.Resolution
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.transaction.annotation.Transactional
 
 interface ResolutionRepository: JpaRepository<Resolution, Long>, QueryResolutionRepository{
+    @Modifying
+    @Transactional
+    @Query("UPDATE Resolution r SET r.dailyStatus = false")
+    fun resetResolutionDailyStatus2()
 }

--- a/src/main/kotlin/com/example/days/domain/resolution/repository/ResolutionRepositoryImpl.kt
+++ b/src/main/kotlin/com/example/days/domain/resolution/repository/ResolutionRepositoryImpl.kt
@@ -10,6 +10,7 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 
 @Repository
 class ResolutionRepositoryImpl: QueryDslSupport(), QueryResolutionRepository {
@@ -33,5 +34,13 @@ class ResolutionRepositoryImpl: QueryDslSupport(), QueryResolutionRepository {
 
         val contents = query.fetch()
         return PageImpl(contents, pageable, totalCount)
+    }
+
+    @Transactional
+    override fun resetResolutionDailyStatus() {
+        queryFactory
+            .update(resolution)
+            .set(resolution.dailyStatus, false)
+            .execute()
     }
 }

--- a/src/main/kotlin/com/example/days/domain/resolution/service/ResolutionServiceImpl.kt
+++ b/src/main/kotlin/com/example/days/domain/resolution/service/ResolutionServiceImpl.kt
@@ -11,6 +11,8 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 
 @Service
@@ -18,7 +20,7 @@ class ResolutionServiceImpl(
     private val resolutionRepository: ResolutionRepository,
     private val userRepository: UserRepository,
     private val categoryRepository: CategoryRepository
-): ResolutionService {
+) : ResolutionService {
     @Transactional
     override fun createResolution(request: ResolutionRequest, userId: Long): ResolutionResponse {
         val user = userRepository.findByIdOrNull(userId) ?: TODO()
@@ -41,32 +43,34 @@ class ResolutionServiceImpl(
     override fun updateResolution(resolutionId: Long, userId: Long, request: ResolutionRequest): ResolutionResponse {
         val category = categoryRepository.findByName(request.category) ?: TODO()
         val updatedResolution = getByIdOrNull(resolutionId)
-        if(updatedResolution.author.id == userId){
+        if (updatedResolution.author.id == userId) {
             updatedResolution.updateResolution(request.title, request.description, category)
             return ResolutionResponse.from(updatedResolution)
-        }
-        else TODO("예외처리")
+        } else TODO("예외처리")
 
     }
 
     @Transactional
     override fun deleteResolution(resolutionId: Long, userId: Long) {
         val resolution = getByIdOrNull(resolutionId)
-        if (resolution.author.id == userId){
+        if (resolution.author.id == userId) {
             resolutionRepository.delete(resolution)
-        }
-        else TODO("예외처리")
+        } else TODO("예외처리")
     }
 
-//    테스트 시 ( 3분에 한번 동작 )
-//    @Scheduled(fixedRate = 180000)
-    @Scheduled(cron = "0 0 0 * * *")
-    fun resetResolutionDailyStatus() {
+    // 테스트 시 ( 3분에 한번 동작 )
+    @Scheduled(fixedRate = 180000)
+//    @Scheduled(cron = "0 0 0 * * *")
+    fun resetResolutionStatus() {
         // ^오^
         // resetResolutionDailyStatus, resetResolutionDailyStatus2 이렇게 2가지 버젼이 있습니다.
         // 첫번째 건 queryDSL, 두번째건 JPQL 을 이용한 메서드입니다.
         // 어떤 방법이 이득인지 고민입니다.
         resolutionRepository.resetResolutionDailyStatus2()
+        // 테스트 시
+//        val today: LocalDateTime = LocalDateTime.now()
+        val today: LocalDate = LocalDate.now()
+        resolutionRepository.checkResolutionDeadline(today)
     }
 
     fun getByIdOrNull(id: Long) = resolutionRepository.findByIdOrNull(id) ?: TODO("예외처리 구현예정")

--- a/src/main/kotlin/com/example/days/domain/resolution/service/ResolutionServiceImpl.kt
+++ b/src/main/kotlin/com/example/days/domain/resolution/service/ResolutionServiceImpl.kt
@@ -8,6 +8,7 @@ import com.example.days.domain.user.repository.UserRepository
 import com.example.days.global.common.SortOrder
 import org.springframework.data.domain.Page
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -55,6 +56,17 @@ class ResolutionServiceImpl(
             resolutionRepository.delete(resolution)
         }
         else TODO("예외처리")
+    }
+
+//    테스트 시 ( 3분에 한번 동작 )
+//    @Scheduled(fixedRate = 180000)
+    @Scheduled(cron = "0 0 0 * * *")
+    fun resetResolutionDailyStatus() {
+        // ^오^
+        // resetResolutionDailyStatus, resetResolutionDailyStatus2 이렇게 2가지 버젼이 있습니다.
+        // 첫번째 건 queryDSL, 두번째건 JPQL 을 이용한 메서드입니다.
+        // 어떤 방법이 이득인지 고민입니다.
+        resolutionRepository.resetResolutionDailyStatus2()
     }
 
     fun getByIdOrNull(id: Long) = resolutionRepository.findByIdOrNull(id) ?: TODO("예외처리 구현예정")


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #51 

## 📝작업 내용

> 목표 관련 세부 기능들을 전체적으로 추가했습니다.
> 1. 데일리 체크 시 진행도가 올라가도록 기능을 추가했습니다.
> 2. 데일리 체크를 1일1회로 제한했습니다.
> 3. 데드라인 도달 시 데일리체크 기능이 닫히도록 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ResolutionServiceImpl 부분에 resetResolutionStatus 메서드에 주석한 내용입니다.
> // resetResolutionDailyStatus, resetResolutionDailyStatus2 이렇게 2가지 버젼이 있습니다.
   // 첫번째 건 queryDSL, 두번째건 JPQL 을 이용한 메서드입니다.
   // 어떤 방법이 이득인지 고민입니다.
